### PR TITLE
Add dev heroku deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ deploy:
       branch: master
   - provider: heroku
     api_key:
-      secure: "TODO"
+      secure: "mNxxK2tzpt1O96FMeG4vrkwO+GqvM6LloDqmFHQWxSzj4k3W1Njd1UZTRLEycpG/0PU6+6BEnxzqiasUsIb05ijwD7DaENznGiKpk1NikDRh8ohstaH9CMx7C2EpDFQSjEflY0bYEr9UWm5Pa8s93P8rU8sNr4+bLi0HaHcqwsfdI1Rt0kPZ3b+kgyQv2TgBIlp4J92MVPMTkGG0TWvfoblGJ8uCfOnOQ9I6kLIG9WOn3ihF8vucsymzonCoYVwBf7Iy5PgFsUqeAv4l2Pyclp2s56vhsVIwRX+WID/yqAZP1VUsvyWT7JmHnSELnumne+NNQsl2JEMFzip7//iT3vf8rveZtLz/R7hJRBc58rH4Gw7M8NI9MJL7X+91vYxnOAadh0jtePJTtDmvgSeZBsbyim98HsGOkINmajH+esjHGDqbJqfzxoQBthEqU4y6ekxJm5uNsR9+UjkxKzIl39xGHvHwuHFSnz8PHZWBAKE6Cq2pPMiPKk2beiwl250S0crm2jPAFyJw8DHA9U6xkZGj8T/BgT+e3lr83ubynfvXN52fZxWnwetNLdcuIkHaj9MLL27mV2NWv49v5feptQeQ5DY9XRGiWZF7S/2AkhUXT4izP5TkUGXMJO+GV62I6cDs6hXtYWOXFZr+H4JVmsRJvSYcvSyjLKW+bnhLIRo="
     on:
       branch: development

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,19 @@ services:
   - postgresql
   - redis-server
 deploy:
-  provider: elasticbeanstalk
-  access_key_id:
-    secure: "OQA+w0pHLHSKnP/LnI+Uh2kMUZbCh+sBO/AnOBZ/HXf4RndWo1zeBthtx0ry61E/CniuvK/I1oZ5MwV4Bb5rVLTpZvMyL7Eca98+u+KdO86+li0+rEB654Kqwj+ZvkaQOVPjhSSMa+zZTMfuXwT+ukXoTCa/0ZNmzQX43oe2Tz51lW1NlO5iGa+cFhaZoE5aGIrmWj+oCREHFe4Gg8h0RzUODRq+4FDC5mOQshyALn3asVKWJCHfcMY1X7dkc/Fw/hn5qe1/UPfZtqrJXQzd/DoSV9YqAN49gB4jK08TpzOhiTTfX5OlnWiffY6ck38hfNiGdWNuI5Y8HYgMPoV4BomLNUkyUbuheYZcI7Kp0Ax2gOQPZ7BXoavMxwGe+ewmsrqcXNUr1E9P+sq763d7VG48f+l+B0mm7oT6Xm8BtVOej8NHEtDEYV28gw60FFLpVuL+qMLOi44/Ckx9jth2Y6NNxrpRoyJmj89eJ3nkXsjBUI62gNYLu3h4q2gMXK3CqMPsf3noD40YBbcaPoYD1S31B8NxjESL33UDpXD5dvnTDkwYw/Z6orG8188Ik2uEqGeNCSnq+7gW7NMM5KQpV5dF/iK+mSRo3oS2ASrfM2wsEwW8gIEDITB8j0M1EHE0BKGCTUkhgiofVQW//U9rbB12hWAkHpOb5BtdICpeOiQ="
-  secret_access_key:
-    secure: "QGzy2D7eVqrq6xhM6tdohfBmsXk/rZO63erc3qPrfhDw/3GYXfTQIIIsrUijO7sNdFcoEJ28Z1v/C2o4QZyBQES5RoeU/GmY0fwAuz7xh/gMqT2Vx7VE69dDzxUV8l1bUY33FhLErER/8XMYVKngfnP0p5wcA+RBTsrqSr37KzynvKFS3kynm+IQa1sYNzuuo8qVRZ8oJjYsP5q9mR0AcWN+C5yzyiaFp7c2FCCF9O+PJfjeKJRXHvuHTCKSJOMmltw7K8SsHg4ryouAqCwWTdnzoC9+/9Wg9f4J2gm13ynBNpVQzrKLG0wdWJC2DQPqWqxcZYvkKHoawxusuIhjl3kLRcgE9TGxz4FCegjDihNLRwLxoTHLygw3ZnZMizbuj4smThwbUQW+TAIth2QLgfJsxteLShFbbHI23Lhxn1gjF5Oo883q68/W2J5rn7jgXDua93oBX46okHJiR0J5jLDTbkZM8RYM6xKXKFcggZYT1+8gH+SBRm9Uoyz9i1Jl77hQKCZbpW7bu6fIYc6kgWcnCjT6iPUs/y+xckDEm3oHmJ2rlST0wTUF5oQtw47Kq4fyYZxM3VryeS2NpGhgayde8rXrYXF8myEoBHTGtIWBVo31LF1uvizPfbS/CwAIsxYLrnpjgRYS5SYj7FPALsc8iImliuy3eOZvsUtpx9M="
-  region: ap-southeast-2
-  app: umbo
-  env: Umbo-env
-  bucket_name: elasticbeanstalk-ap-southeast-2-453784662248
+  - provider: elasticbeanstalk
+    access_key_id:
+      secure: "OQA+w0pHLHSKnP/LnI+Uh2kMUZbCh+sBO/AnOBZ/HXf4RndWo1zeBthtx0ry61E/CniuvK/I1oZ5MwV4Bb5rVLTpZvMyL7Eca98+u+KdO86+li0+rEB654Kqwj+ZvkaQOVPjhSSMa+zZTMfuXwT+ukXoTCa/0ZNmzQX43oe2Tz51lW1NlO5iGa+cFhaZoE5aGIrmWj+oCREHFe4Gg8h0RzUODRq+4FDC5mOQshyALn3asVKWJCHfcMY1X7dkc/Fw/hn5qe1/UPfZtqrJXQzd/DoSV9YqAN49gB4jK08TpzOhiTTfX5OlnWiffY6ck38hfNiGdWNuI5Y8HYgMPoV4BomLNUkyUbuheYZcI7Kp0Ax2gOQPZ7BXoavMxwGe+ewmsrqcXNUr1E9P+sq763d7VG48f+l+B0mm7oT6Xm8BtVOej8NHEtDEYV28gw60FFLpVuL+qMLOi44/Ckx9jth2Y6NNxrpRoyJmj89eJ3nkXsjBUI62gNYLu3h4q2gMXK3CqMPsf3noD40YBbcaPoYD1S31B8NxjESL33UDpXD5dvnTDkwYw/Z6orG8188Ik2uEqGeNCSnq+7gW7NMM5KQpV5dF/iK+mSRo3oS2ASrfM2wsEwW8gIEDITB8j0M1EHE0BKGCTUkhgiofVQW//U9rbB12hWAkHpOb5BtdICpeOiQ="
+    secret_access_key:
+      secure: "QGzy2D7eVqrq6xhM6tdohfBmsXk/rZO63erc3qPrfhDw/3GYXfTQIIIsrUijO7sNdFcoEJ28Z1v/C2o4QZyBQES5RoeU/GmY0fwAuz7xh/gMqT2Vx7VE69dDzxUV8l1bUY33FhLErER/8XMYVKngfnP0p5wcA+RBTsrqSr37KzynvKFS3kynm+IQa1sYNzuuo8qVRZ8oJjYsP5q9mR0AcWN+C5yzyiaFp7c2FCCF9O+PJfjeKJRXHvuHTCKSJOMmltw7K8SsHg4ryouAqCwWTdnzoC9+/9Wg9f4J2gm13ynBNpVQzrKLG0wdWJC2DQPqWqxcZYvkKHoawxusuIhjl3kLRcgE9TGxz4FCegjDihNLRwLxoTHLygw3ZnZMizbuj4smThwbUQW+TAIth2QLgfJsxteLShFbbHI23Lhxn1gjF5Oo883q68/W2J5rn7jgXDua93oBX46okHJiR0J5jLDTbkZM8RYM6xKXKFcggZYT1+8gH+SBRm9Uoyz9i1Jl77hQKCZbpW7bu6fIYc6kgWcnCjT6iPUs/y+xckDEm3oHmJ2rlST0wTUF5oQtw47Kq4fyYZxM3VryeS2NpGhgayde8rXrYXF8myEoBHTGtIWBVo31LF1uvizPfbS/CwAIsxYLrnpjgRYS5SYj7FPALsc8iImliuy3eOZvsUtpx9M="
+    region: ap-southeast-2
+    app: umbo
+    env: Umbo-env
+    bucket_name: elasticbeanstalk-ap-southeast-2-453784662248
+    on:
+      branch: master
+  - provider: heroku
+    api_key:
+      secure: "TODO"
+    on:
+      branch: development


### PR DESCRIPTION
With these settings travis should deploy `master` to AWS and `development` to heroku.

You can get the encrypted value of your key by running:
```
travis encrypt $(heroku auth:token)
```
as decribed [here](https://docs.travis-ci.com/user/deployment/heroku/).